### PR TITLE
Add README to make the production instance more discoverable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+`zsh-guide` .zshrc Generator
+============================
+
+This directory is the source code of the .zshrc Generator hosted
+at <https://storage.googleapis.com/zsh-guide/index.html>, which see
+for further details.


### PR DESCRIPTION
The URL to the production instance isn't currently anywhere in this repository.  This PR changes that.

Alternatively (or additionally), the repository's URL could be set to the production instance's URL (by clicking the gear icon that's above the words "No description, website, or topics provided" in https://github.com/phy1729/zsh-guide).